### PR TITLE
[기능 추가] MyBatis와 스프링 연동

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,11 +72,34 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- JUnit 4 -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- Database Dependencies -->
 		<dependency>
 			<groupId>com.oracle.ojdbc</groupId>
 			<artifactId>ojdbc8</artifactId>
 			<version>19.3.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.mybatis</groupId>
+			<artifactId>mybatis</artifactId>
+			<version>3.4.6</version>
+		</dependency>
+		<dependency>
+			<groupId>org.mybatis</groupId>
+			<artifactId>mybatis-spring</artifactId>
+			<version>1.3.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-tx</artifactId>
+			<version>${org.springframework-version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -127,14 +150,6 @@
 			<groupId>org.bgee.log4jdbc-log4j2</groupId>
 			<artifactId>log4jdbc-log4j2-jdbc4</artifactId>
 			<version>1.16</version>
-		</dependency>
-
-		<!-- JUnit 4 -->
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.12</version>
-			<scope>test</scope>
 		</dependency>
 
 	</dependencies>

--- a/src/main/java/org/zerock/config/RootConfig.java
+++ b/src/main/java/org/zerock/config/RootConfig.java
@@ -2,6 +2,9 @@ package org.zerock.config;
 
 import javax.sql.DataSource;
 
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.mybatis.spring.SqlSessionFactoryBean;
+import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -11,6 +14,7 @@ import com.zaxxer.hikari.HikariDataSource;
 
 @Configuration
 @ComponentScan(basePackages= {"org.zerock.sample"})
+@MapperScan(basePackages= {"org.zerock.mapper"})
 public class RootConfig {
 	
 	@Bean
@@ -27,6 +31,13 @@ public class RootConfig {
 		HikariDataSource dataSource = new HikariDataSource(hikariConfig);
 		
 		return dataSource;
+	}
+	
+	@Bean
+	public SqlSessionFactory sqlSessionFactory() throws Exception {
+		SqlSessionFactoryBean sqlSessionFactory = new SqlSessionFactoryBean();
+		sqlSessionFactory.setDataSource(dataSource());
+		return (SqlSessionFactory) sqlSessionFactory.getObject();
 	}
 
 }

--- a/src/main/java/org/zerock/mapper/TimeMapper.java
+++ b/src/main/java/org/zerock/mapper/TimeMapper.java
@@ -1,0 +1,10 @@
+package org.zerock.mapper;
+
+import org.apache.ibatis.annotations.Select;
+
+public interface TimeMapper {
+	
+	@Select("SELECT sysdate FROM dual")
+	public String getTime();
+	
+}

--- a/src/test/java/org/zerock/persistence/DataSourceTests.java
+++ b/src/test/java/org/zerock/persistence/DataSourceTests.java
@@ -6,6 +6,8 @@ import java.sql.Connection;
 
 import javax.sql.DataSource;
 
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +29,20 @@ public class DataSourceTests {
 		try (Connection con = dataSource.getConnection()){
 			log.info(con);
 		}catch(Exception e) {
+			fail(e.getMessage());
+		}
+	}
+	
+	@Setter(onMethod_ = { @Autowired})
+	private SqlSessionFactory sqlSessionFactory;
+	@Test
+	public void testMyBatis() {
+		try (SqlSession session = sqlSessionFactory.openSession();
+				Connection con = session.getConnection();
+				){
+			log.info(session);
+			log.info(con);
+		} catch (Exception e) {
 			fail(e.getMessage());
 		}
 	}

--- a/src/test/java/org/zerock/persistence/TimeMapperTests.java
+++ b/src/test/java/org/zerock/persistence/TimeMapperTests.java
@@ -1,0 +1,27 @@
+package org.zerock.persistence;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.zerock.mapper.TimeMapper;
+
+import lombok.Setter;
+import lombok.extern.log4j.Log4j;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = { org.zerock.config.RootConfig.class })
+@Log4j
+public class TimeMapperTests {
+	
+	@Setter(onMethod_ = @Autowired)
+	private TimeMapper timeMapper;
+	
+	@Test
+	public void testGetTime() {
+		log.info(timeMapper.getClass().getName());
+		log.info(timeMapper.getTime());
+	}
+
+}

--- a/src/test/resources/log4j.xml
+++ b/src/test/resources/log4j.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+	<appender name="console" class="org.apache.log4j.ConsoleAppender">
+		<layout class="org.apache.log4j.PatternLayout">
+			<param name="ConversionPattern" value="%d{ISO8601} %-5p [%t] %c: %m%n" />
+		</layout>
+	</appender>
+	<root>
+		<level value="info" />
+		<appender-ref ref="console" />
+	</root>
+	<logger name="jdbc.audit" additivity="false">
+		<level value="warn" />
+		<appender-ref ref="console" />
+	</logger>
+	<logger name="jdbc.resultset" additivity="false">
+		<level value="warn" />
+		<appender-ref ref="console" />
+	</logger>
+	<logger name="jdbc.connection" additivity="false">
+		<level value="warn" />
+		<appender-ref ref="console" />
+	</logger>
+</log4j:configuration>


### PR DESCRIPTION
pom.xml
(MyBatis와 mybatis-spring을 사용하기 위해서 추가적인 라이브러리들(spring-jdbc(스프링에서 데이터베이스 처리), spring-tx(스프링에서 트랜잭션 처리), mybatis(연동 작업 처리), mybatis-spring(연동 작업 처리)) 설정)

src/main/java/org/zerock/config/RootConfig.java
(스프링에 SQLSessionFactory(내부적으로 SQLSession 만들어 내는), SQLSession(Connection을 생성하거나 원하는 SQL을 전달하고, 결과를 리턴 받는) 등록)

src/test/java/org/zerock/persistence/DataSourceTests.java
(SqlSession을 사용해 보는 테스트 작성)

src/main/java/org/zerock/mapper/TimeMapper.java
(SQL 자동 처리 별도 설정을 위해 Mapper 작성(Mapper 인터페이스 사용))
(cf. MyBatis가 동작할 때 Mapper를 인식할 수 있도록 RootConfig 클래스에 @MapperScan 추가)

src/test/java/org/zerock/persistence/TimeMapperTests.java
(MyBatis-Spring이 'Mapper 인터페이스'를 이용해서 '실제 SQL 처리가 되는 클래스'를 자동으로 생성하는지 테스트하는 코드 작성)

src/test/resources/log4j.xml
(로그 레벨 설정)